### PR TITLE
Fixed problem with mkdirp

### DIFF
--- a/src/commands/icon-generator.ts
+++ b/src/commands/icon-generator.ts
@@ -149,7 +149,7 @@ export default class IconGenerator {
 
   private async generateIOSIcons(outputDirPath: string): Promise<void> {
     // Create output path
-    await mkdirp(outputDirPath);
+    mkdirp(outputDirPath);
 
     // Create required images
     for (const { baseSize, name, idiom, scales } of this.iOSSizes) {
@@ -216,7 +216,7 @@ export default class IconGenerator {
 
     // Create density-specific path
     const dDir = density !== 'web' ? path.join(baseOutputDirPath, `res/mipmap-${density}`) : baseOutputDirPath;
-    await mkdirp(dDir);
+    mkdirp(dDir);
 
     // resize & cut image - rounded corners
     await sharp(this.sourceImageFilePath)

--- a/src/commands/splash-generator.ts
+++ b/src/commands/splash-generator.ts
@@ -117,13 +117,13 @@ export default class SplashGenerator {
 
     // Create base output path
     const outputDirPath = './android/app/src/main/res';
-    await mkdirp(outputDirPath);
+    mkdirp(outputDirPath);
 
     // Create required images
     for (const { density, width, height } of this.androidSizes) {
       console.info(`- Generate Android Splashscreen (${density})...`);
       // Create density specific folder, if it doesn't exists
-      await mkdirp(path.join(outputDirPath, `drawable-${density}`));
+      mkdirp(path.join(outputDirPath, `drawable-${density}`));
 
       // Resize image
       await sharp(this.sourceImageFilePath)
@@ -140,7 +140,7 @@ export default class SplashGenerator {
 
     // Create output path
     const outputDirPath = `./ios/${this.appName}/Images.xcassets/Splashscreen.imageset`;
-    await mkdirp(outputDirPath);
+    mkdirp(outputDirPath);
 
     // Create Splashscreen images
     await this.generateIOSSplash(outputDirPath);


### PR DESCRIPTION
Removed the await before the mkdirp, because I saw that these cause problems during the generation of the iOS images.
As you can see it doesn't generate anything.
![image](https://user-images.githubusercontent.com/3645225/78861636-8c10fb80-7a35-11ea-9401-b117f5aa9ece.png)

Moreover if the folders AppIcon and/or Splashscreen are not in place, the generation fails.